### PR TITLE
Feature/port selection

### DIFF
--- a/backend/environment.env
+++ b/backend/environment.env
@@ -6,3 +6,5 @@ export JWT_SECRET_KEY='you-very-long-very-secret-jwt-key'
 export SENDGRID_API_KEY='YOUR_API_KEY'
 export SENDGRID_TO_EMAIL='YOUR@EMAIL.ADDRESS'
 export SENDGRID_BIRTHDAY_TEMPLATE_ID='sendgridtemplateid'
+
+export HOST_PORT='8080'

--- a/backend/main.go
+++ b/backend/main.go
@@ -86,7 +86,11 @@ func main() {
 	//	log.Fatalf("Failed to start HTTPS server: %s", err)
 	//}
 
-	r.Run(":8080")
+	port := os.Getenv("HOST_PORT")
+	if port == "" {
+		port = "8080"
+	}
+	r.Run(fmt.Sprintf(":%s"))
 
 }
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -63,12 +63,10 @@ func main() {
 
 	r.Static("/static", "./frontend/dist")
 
-	//test.InjectTestData(db)
+	// test.InjectTestData(db)
 
 	// Register all routes from routes.go
 	routes.RegisterRoutes(r)
-
-	log.Println("Server listening on Port 8080...")
 
 	//TODO setup https
 	// Start HTTP server to redirect to HTTPS
@@ -90,8 +88,10 @@ func main() {
 	if port == "" {
 		port = "8080"
 	}
-	r.Run(fmt.Sprintf(":%s"))
 
+	log.Println(fmt.Sprintf("Server listening on Port %s...", port))
+
+	r.Run(fmt.Sprintf(":%s", port))
 }
 
 func sendBirthdayReminders(db *gorm.DB) {


### PR DESCRIPTION
This pull request adds a new feature that allows the backend server's port to be specified via the HOST_PORT environment variable. If not set, the server defaults to port 8080. This change enhances deployment flexibility without affecting existing setups. Users can set the port by exporting HOST_PORT before launching the application. Tests confirm the feature works as expected in various environments. Please review and provide feedback.