### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   e2e:
+    permissions:
+      contents: read
+      actions: read
     name: Run E2E Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
Potential fix for [https://github.com/fbuchner/meerkat-crm/security/code-scanning/7](https://github.com/fbuchner/meerkat-crm/security/code-scanning/7)

In general, fix this by explicitly setting a `permissions` block in the workflow to restrict the `GITHUB_TOKEN` to the minimum needed, instead of relying on repository defaults. You can set it at the workflow root (applies to all jobs without their own `permissions`) or at the specific job level.

For this workflow, the `e2e` job only needs to check out the code and upload artifacts. Those actions only require read access to the repository contents and the ability to upload artifacts, which is governed by the `actions` permission. A safe minimal configuration is `contents: read` and `actions: read`. To avoid inadvertently breaking anything, we will set permissions at the job level for `e2e` so the change is tightly scoped.

Concretely, in `.github/workflows/e2e-tests.yml`, under `jobs: e2e:` and before `name: Run E2E Tests`, add:

```yaml
    permissions:
      contents: read
      actions: read
```

This restricts the `GITHUB_TOKEN` for this job while preserving existing behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
