### PR TITLE
Route /health endpoint through to backend

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -15,6 +15,16 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none';" always;
 
+    # Health check proxy - forward to backend
+    location /health {
+        proxy_pass http://backend:8080/health;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # API proxy - forward requests to backend
     location /api/ {
         proxy_pass http://backend:8080/api/;


### PR DESCRIPTION
Expose the /health API currently only reachable within the docker network to the frontend (for e.g. Uptime Kuma)