### PR TITLE
Changed min allowed chars for username to 1

### DIFF
--- a/backend/middleware/validation_custom_test.go
+++ b/backend/middleware/validation_custom_test.go
@@ -25,7 +25,7 @@ func TestValidationWithErrorSystem(t *testing.T) {
 
 	type TestStruct struct {
 		Email    string `json:"email" validate:"required,email"`
-		Username string `json:"username" validate:"required,min=3,max=20"`
+		Username string `json:"username" validate:"required,min=1,max=20"`
 		Phone    string `json:"phone" validate:"required,phone"`
 	}
 

--- a/backend/middleware/validation_integration_test.go
+++ b/backend/middleware/validation_integration_test.go
@@ -24,7 +24,7 @@ func init() {
 
 type TestValidationStruct struct {
 	Email    string `json:"email" validate:"required,email"`
-	Username string `json:"username" validate:"required,min=3,max=20"`
+	Username string `json:"username" validate:"required,min=1,max=20"`
 	Phone    string `json:"phone" validate:"required,phone"`
 	Birthday string `json:"birthday" validate:"omitempty,birthday"`
 	Password string `json:"password" validate:"required,strong_password"`

--- a/backend/middleware/validation_test.go
+++ b/backend/middleware/validation_test.go
@@ -237,6 +237,16 @@ func TestValidateStruct_NoAtSign(t *testing.T) {
 			isValid: true,
 		},
 		{
+			name:    "valid username with 1 character",
+			input:   "j",
+			isValid: true,
+		},
+		{
+			name:    "valid username with 2 characters (non-latin)",
+			input:   "象形",
+			isValid: true,
+		},
+		{
 			name:    "invalid - contains @",
 			input:   "john@doe",
 			isValid: false,

--- a/backend/models/dtos.go
+++ b/backend/models/dtos.go
@@ -44,7 +44,7 @@ type CustomFieldNamesInput struct {
 // UserRegistrationInput represents the DTO for user registration
 // This DTO intentionally excludes IsAdmin to prevent mass assignment attacks
 type UserRegistrationInput struct {
-	Username string `json:"username" validate:"required,min=3,max=50,no_at_sign"`
+	Username string `json:"username" validate:"required,min=1,max=50,no_at_sign"`
 	Email    string `json:"email" validate:"required,email"`
 	Password string `json:"password" validate:"required,min=8,strong_password"`
 	Language string `json:"language" validate:"omitempty,oneof=en de"`
@@ -132,7 +132,7 @@ type AdminUserResponse struct {
 
 // AdminUserUpdateInput - DTO for admin updating a user
 type AdminUserUpdateInput struct {
-	Username *string `json:"username" validate:"omitempty,min=3,max=50,no_at_sign"`
+	Username *string `json:"username" validate:"omitempty,min=1,max=50,no_at_sign"`
 	Email    *string `json:"email" validate:"omitempty,email"`
 	Password *string `json:"password" validate:"omitempty,min=8,strong_password"`
 	IsAdmin  *bool   `json:"is_admin"`

--- a/backend/models/user.go
+++ b/backend/models/user.go
@@ -8,7 +8,7 @@ import (
 
 type User struct {
 	gorm.Model
-	Username                 string     `gorm:"unique" validate:"required,min=3,max=50,no_at_sign"`
+	Username                 string     `gorm:"unique" validate:"required,min=1,max=50,no_at_sign"`
 	Password                 string     `validate:"required,min=8,strong_password"`
 	Email                    string     `gorm:"unique" validate:"required,email"`
 	Language                 string     `gorm:"default:'en'" json:"language" validate:"omitempty,oneof=en de"`


### PR DESCRIPTION
There are situations where 1 or 2 character usernames are used, including in non-Latin character languages (e.g., Chinese, Korean, Japanese). Personally, for things I self-host I usually only use 1 character usernames.

While I've not programmed in Go before, my experience with other languages (Rust, JS/TS, PHP) and Postgres allows me to see that only an ORM validation check forces the `min=3` character limit for a `username`. So, I've lowered that limit to `1`.

No AI was used in the generation of this pull request.

I've tested it locally with the following usernames (I've also added some validation tests which passes):
<img width="690" height="379" alt="user-management-view" src="https://github.com/user-attachments/assets/696e98a3-cacb-43d6-af14-1518bf39bf59" />

It also appears that the `invalid - contains @` still applies with a single char `@`:
<img width="400" height="449" alt="at-still-fails" src="https://github.com/user-attachments/assets/a6e0215d-807c-4990-b651-a6afd23d5ba7" />
