### PR TITLE
Fix contacts list to support cmd-click new tab

### DIFF
--- a/frontend/src/ContactsPage.tsx
+++ b/frontend/src/ContactsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useMemo, useRef, useCallback } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useContacts } from './hooks/useContacts';
 import { getCircles } from './api/contacts';
@@ -223,17 +223,20 @@ export default function ContactsPage() {
             {filteredContacts.map(contact => (
               <Card
                 key={contact.ID}
+                component={Link}
+                to={`/contacts/${contact.ID}`}
                 sx={{
                   display: 'flex',
                   alignItems: 'center',
                   p: 1.5,
                   cursor: 'pointer',
+                  textDecoration: 'none',
+                  color: 'inherit',
                   bgcolor: contact.archived ? 'action.disabledBackground' : undefined,
                   '&:hover': {
                     bgcolor: 'action.hover'
                   }
                 }}
-                onClick={() => navigate(`/contacts/${contact.ID}`)}
               >
                 <Avatar src={contact.photo_thumbnail || undefined} sx={{ width: 48, height: 48, mr: 1.5, bgcolor: 'primary.main' }}>
                   {contact.firstname.charAt(0)}
@@ -260,7 +263,7 @@ export default function ContactsPage() {
                         size="small"
                         variant="outlined"
                         clickable
-                        onClick={(e) => { e.stopPropagation(); setSelectedCircle(circle); setPage(1); }}
+                        onClick={(e) => { e.preventDefault(); e.stopPropagation(); setSelectedCircle(circle); setPage(1); }}
                         sx={{ height: 20, fontSize: '0.75rem' }}
                       />
                     ))}


### PR DESCRIPTION
## Summary
- Resolves #110
- Cards on the contacts list used `onClick` with `navigate()`, so cmd/ctrl-click didn't open the contact in a new tab. Switched the card to render as a `Link` (same pattern already used by the dashboard's random-contacts cards), giving it a real `<a href>` that the browser can open in a new tab.
- Updated the circle-chip `onClick` inside the card to also call `preventDefault()` so chip filtering still works without triggering link navigation.

## Test plan
- [x] `yarn start` — click a contact: navigates as before
- [x] cmd-click a contact: opens `/contacts/:id` in a new tab
- [x] click a circle chip on a card: filters by circle, does not navigate to the contact
- [x] archived-contact styling still applied