### PR TITLE
Add typeahead filtering to contact circle dropdown

### DIFF
--- a/frontend/src/components/ContactHeader.tsx
+++ b/frontend/src/components/ContactHeader.tsx
@@ -1,4 +1,4 @@
-import { Box, Card, CardContent, Avatar, Typography, Chip, IconButton, Stack, TextField, MenuItem, Button } from '@mui/material';
+import { Box, Card, CardContent, Avatar, Typography, Chip, IconButton, Stack, TextField, Autocomplete, Button } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import SaveIcon from '@mui/icons-material/Save';
 import CloseIcon from '@mui/icons-material/Close';
@@ -308,28 +308,26 @@ export default function ContactHeader({
                     )}
                   </Stack>
                   <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
-                    <TextField
-                      select
-                      label={t('contacts.selectCircle')}
+                    <Autocomplete
+                      key={contact.circles?.length ?? 0}
                       size="small"
-                      value=""
-                      onChange={(e) => {
-                        const value = e.target.value;
+                      options={availableCircles.filter(c => !contact.circles?.includes(c))}
+                      value={null}
+                      onChange={(_, value) => {
                         if (value) {
                           onAddCircle(value);
                         }
                       }}
-                      sx={{ minWidth: 150 }}
-                    >
-                      <MenuItem value="">{t('contacts.selectCircle')}</MenuItem>
-                      {availableCircles
-                        .filter(c => !contact.circles?.includes(c))
-                        .map(circle => (
-                          <MenuItem key={circle} value={circle}>
-                            {circle}
-                          </MenuItem>
-                        ))}
-                    </TextField>
+                      blurOnSelect
+                      sx={{ minWidth: 200 }}
+                      renderInput={(params) => (
+                        <TextField
+                          {...params}
+                          label={t('contacts.selectCircle')}
+                          size="small"
+                        />
+                      )}
+                    />
                     <TextField
                       size="small"
                       placeholder={t('contactDetail.newCircle')}


### PR DESCRIPTION
## Summary
- Swapped the plain `TextField select` for MUI `Autocomplete` in `ContactHeader.tsx` so users can type to filter existing circles when adding one to a contact.
- Mirrors the UX of the relationship adder (`AddRelationshipDialog.tsx`), which already used `Autocomplete`.
- Client-side filtering only — `availableCircles` is already fully loaded in the parent, so no server-side search is needed.
- `key={contact.circles?.length}` forces a clean remount after each add so the input clears and the user can immediately type to add another circle.
<img width="360" height="325" alt="image" src="https://github.com/user-attachments/assets/673f7879-7149-458d-813c-9d5784fcef58" />
<img width="438" height="324" alt="image" src="https://github.com/user-attachments/assets/cdf023c2-907d-4e57-906c-d2f6e79bdaa5" />


## Test plan
- [x] Open a contact, click the edit pencil next to Circles
- [x] Click the "Select circle" dropdown — options list should appear
- [x] Type part of a circle name — list filters live
- [x] Select a filtered option — circle is added as a chip and input clears
- [x] Add a second circle the same way
- [x] Confirm already-added circles do not appear in the dropdown
- [x] Confirm the "create new circle" text field + add button next to it still work