### PR TITLE
Fix: Add dedicated rate limiter for CardDav

### DIFF
--- a/backend/middleware/rate_limiter.go
+++ b/backend/middleware/rate_limiter.go
@@ -239,6 +239,10 @@ var (
 	// 100 requests per minute with burst of 500
 	apiLimiter = NewIPRateLimiter(rate.Every(600*time.Millisecond), 500)
 
+	// CardDAV rate limiter — higher burst to accommodate bulk sync from clients like vdirsyncer
+	// 10 requests per second sustained, burst of 2500 for initial address book sync
+	cardDAVLimiter = NewIPRateLimiter(rate.Every(100*time.Millisecond), 2500)
+
 	// Per-account rate limiter for login attempts
 	// Tracks failed attempts per username/email with exponential backoff
 	// This is the primary brute force protection mechanism
@@ -275,6 +279,7 @@ func StartCleanupRoutine() {
 			case <-ticker.C:
 				authLimiter.CleanupStaleEntries()
 				apiLimiter.CleanupStaleEntries()
+				cardDAVLimiter.CleanupStaleEntries()
 				accountLimiter.CleanupStaleAccountEntries()
 			case <-cleanupDone:
 				return
@@ -331,4 +336,10 @@ func AuthRateLimitMiddleware() gin.HandlerFunc {
 // APIRateLimitMiddleware applies general rate limiting for API endpoints
 func APIRateLimitMiddleware() gin.HandlerFunc {
 	return RateLimitMiddleware(apiLimiter)
+}
+
+// CardDAVRateLimitMiddleware applies rate limiting for CardDAV endpoints.
+// Uses a higher burst than auth endpoints to allow bulk sync from clients like vdirsyncer.
+func CardDAVRateLimitMiddleware() gin.HandlerFunc {
+	return RateLimitMiddleware(cardDAVLimiter)
 }

--- a/backend/middleware/rate_limiter_test.go
+++ b/backend/middleware/rate_limiter_test.go
@@ -509,6 +509,25 @@ func TestAccountRateLimiter_CleanupPreservesLockedAccounts(t *testing.T) {
 	}
 }
 
+func TestCardDAVRateLimitMiddlewareAllowsBulkRequests(t *testing.T) {
+	testLimiter := NewIPRateLimiter(rate.Every(100*time.Millisecond), 1000)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(RateLimitMiddleware(testLimiter))
+	router.GET("/carddav/test", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	for i := 0; i < 100; i++ {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/carddav/test", nil)
+		req.RemoteAddr = "192.168.1.1:1234"
+		router.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("Request %d got %d, want 200 — burst too small for bulk sync", i+1, w.Code)
+		}
+	}
+}
+
 func TestGetAccountRateLimiter(t *testing.T) {
 	limiter := GetAccountRateLimiter()
 

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -176,7 +176,7 @@ func registerCardDAVRoutes(router *gin.Engine, cfg *config.Config, db *gorm.DB) 
 		c.Set("db", db)
 		c.Next()
 	})
-	cardDAVGroup.Use(middleware.AuthRateLimitMiddleware())
+	cardDAVGroup.Use(middleware.CardDAVRateLimitMiddleware())
 	cardDAVGroup.Use(carddav.BasicAuthMiddleware())
 	{
 		ginHandler := handler.GinHandler()


### PR DESCRIPTION
Issue: CardDav used the default auth rate limiter (2 requests per second, 50 burst). This quickly reached a limit with larger address books
Fix: Implemented a dedicated rate limiter for the CardDav server (10 requests per second, 2500 burst).