### PR TITLE
Add CalDAV activity sync

### DIFF
--- a/backend/controllers/caldav_controller.go
+++ b/backend/controllers/caldav_controller.go
@@ -1,0 +1,55 @@
+package controllers
+
+import (
+	apperrors "meerkat/errors"
+	"meerkat/logger"
+	"meerkat/middleware"
+	"meerkat/models"
+	"meerkat/services"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+func SyncCalDAVActivities(c *gin.Context) {
+	input, err := middleware.GetValidated[models.CalDAVSyncInput](c)
+	if err != nil {
+		apperrors.AbortWithError(c, err)
+		return
+	}
+
+	userID, ok := currentUserID(c)
+	if !ok {
+		return
+	}
+
+	db := c.MustGet("db").(*gorm.DB)
+	result, syncErr := services.NewCalDAVSyncService().Sync(c.Request.Context(), db, userID, *input)
+	if syncErr != nil {
+		logger.FromContext(c).Warn().Err(syncErr).Msg("CalDAV activity sync failed")
+		apperrors.AbortWithError(c, calDAVSyncError(syncErr))
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "CalDAV sync completed",
+		"created": result.Created,
+		"skipped": result.Skipped,
+	})
+}
+
+func calDAVSyncError(err error) *apperrors.AppError {
+	message := err.Error()
+	switch {
+	case strings.Contains(message, "invalid calendar URL"):
+		return apperrors.ErrInvalidInput("url", message)
+	case strings.Contains(message, "one or more contacts"):
+		return apperrors.ErrNotFound("One or more contacts")
+	case strings.Contains(message, "calendar service"):
+		return apperrors.ErrExternal("CalDAV", message)
+	default:
+		return apperrors.ErrOperationFailed("CalDAV sync", message)
+	}
+}

--- a/backend/httputil/fetch.go
+++ b/backend/httputil/fetch.go
@@ -82,62 +82,55 @@ func validateURLForSSRF(rawURL string) (*url.URL, error) {
 	return parsedURL, nil
 }
 
-// FetchImageFromURL fetches an image from a URL with SSRF protection.
-// Returns the image data, content type, and any error.
-// The URL is sanitized to remove whitespace (handles Google VCF format).
-func FetchImageFromURL(imageURL string) ([]byte, string, error) {
-	// Clean URL - remove spaces and newlines (Google VCF format may have these)
-	cleanURL := strings.ReplaceAll(imageURL, " ", "")
-	cleanURL = strings.ReplaceAll(cleanURL, "\n", "")
-	cleanURL = strings.ReplaceAll(cleanURL, "\r", "")
+// ValidateURLForSSRF checks if a URL is safe to fetch from user-provided input.
+func ValidateURLForSSRF(rawURL string) (*url.URL, error) {
+	return validateURLForSSRF(rawURL)
+}
 
-	// Validate the URL format and scheme
-	parsedURL, err := validateURLForSSRF(cleanURL)
+func safeDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	// Extract host from addr (format is host:port)
+	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
-	// Create a custom dialer that validates IP addresses at connection time
-	// This prevents DNS rebinding/TOCTOU attacks
+	// Resolve the hostname to IP addresses
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return nil, errors.New("failed to resolve hostname")
+	}
+
+	// Find a safe IP to connect to
+	var safeIP net.IP
+	for _, ip := range ips {
+		if !isPrivateIP(ip) {
+			safeIP = ip
+			break
+		}
+	}
+
+	if safeIP == nil {
+		return nil, errors.New("access to internal IP addresses is not allowed")
+	}
+
 	safeDialer := &net.Dialer{
 		Timeout:   10 * time.Second,
 		KeepAlive: 10 * time.Second,
 	}
 
-	safeDialContext := func(ctx context.Context, network, addr string) (net.Conn, error) {
-		// Extract host from addr (format is host:port)
-		host, port, err := net.SplitHostPort(addr)
-		if err != nil {
-			return nil, err
-		}
+	// Connect using the validated IP address directly
+	safeAddr := net.JoinHostPort(safeIP.String(), port)
+	return safeDialer.DialContext(ctx, network, safeAddr)
+}
 
-		// Resolve the hostname to IP addresses
-		ips, err := net.LookupIP(host)
-		if err != nil {
-			return nil, errors.New("failed to resolve hostname")
-		}
-
-		// Find a safe IP to connect to
-		var safeIP net.IP
-		for _, ip := range ips {
-			if !isPrivateIP(ip) {
-				safeIP = ip
-				break
-			}
-		}
-
-		if safeIP == nil {
-			return nil, errors.New("access to internal IP addresses is not allowed")
-		}
-
-		// Connect using the validated IP address directly
-		safeAddr := net.JoinHostPort(safeIP.String(), port)
-		return safeDialer.DialContext(ctx, network, safeAddr)
+// NewSafeHTTPClient returns an HTTP client that blocks private/reserved network targets.
+func NewSafeHTTPClient(timeout time.Duration) *http.Client {
+	if timeout <= 0 {
+		timeout = 15 * time.Second
 	}
 
-	// Create HTTP client with custom transport that validates IPs at connection time
-	client := &http.Client{
-		Timeout: 15 * time.Second,
+	return &http.Client{
+		Timeout: timeout,
 		Transport: &http.Transport{
 			DialContext: safeDialContext,
 		},
@@ -153,6 +146,25 @@ func FetchImageFromURL(imageURL string) ([]byte, string, error) {
 			return nil
 		},
 	}
+}
+
+// FetchImageFromURL fetches an image from a URL with SSRF protection.
+// Returns the image data, content type, and any error.
+// The URL is sanitized to remove whitespace (handles Google VCF format).
+func FetchImageFromURL(imageURL string) ([]byte, string, error) {
+	// Clean URL - remove spaces and newlines (Google VCF format may have these)
+	cleanURL := strings.ReplaceAll(imageURL, " ", "")
+	cleanURL = strings.ReplaceAll(cleanURL, "\n", "")
+	cleanURL = strings.ReplaceAll(cleanURL, "\r", "")
+
+	// Validate the URL format and scheme
+	parsedURL, err := validateURLForSSRF(cleanURL)
+	if err != nil {
+		return nil, "", err
+	}
+
+	// Create HTTP client with custom transport that validates IPs at connection time.
+	client := NewSafeHTTPClient(15 * time.Second)
 
 	// Fetch the image using the validated URL
 	req, err := http.NewRequest("GET", parsedURL.String(), nil)

--- a/backend/models/dtos.go
+++ b/backend/models/dtos.go
@@ -11,6 +11,15 @@ type ActivityInput struct {
 	ContactIDs  []uint    `json:"contact_ids"` // Accept an array of contact IDs for many-to-many association
 }
 
+// CalDAVSyncInput connects to a CalDAV calendar once and imports VEVENTs as activities.
+type CalDAVSyncInput struct {
+	URL        string `json:"url" validate:"required,url,max=2048"`
+	Username   string `json:"username" validate:"required,max=200"`
+	Password   string `json:"password" validate:"required,max=500"`
+	ContactIDs []uint `json:"contact_ids"`
+	Limit      int    `json:"limit" validate:"omitempty,min=1,max=200"`
+}
+
 // NoteInput represents the DTO for creating/updating notes
 type NoteInput struct {
 	Content   string    `json:"content" validate:"required,min=1,max=5000"`

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -112,6 +112,7 @@ func RegisterRoutes(router *gin.Engine, cfg *config.Config, db *gorm.DB, oidcPro
 			protected.GET("/activities/:id", controllers.GetActivity)
 			protected.PUT("/activities/:id", middleware.ValidateJSONMiddleware(&models.ActivityInput{}), controllers.UpdateActivity)
 			protected.DELETE("/activities/:id", controllers.DeleteActivity)
+			protected.POST("/caldav/sync", middleware.ValidateJSONMiddleware(&models.CalDAVSyncInput{}), controllers.SyncCalDAVActivities)
 
 			// Reminder routes
 			protected.GET("/reminders", controllers.GetAllReminders)

--- a/backend/services/caldav_sync_service.go
+++ b/backend/services/caldav_sync_service.go
@@ -1,0 +1,459 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"meerkat/httputil"
+	"meerkat/models"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+const (
+	defaultCalDAVSyncLimit = 200
+	maxCalDAVResponseSize  = 10 * 1024 * 1024
+)
+
+// CalDAVSyncResult summarizes a CalDAV activity sync run.
+type CalDAVSyncResult struct {
+	Created int `json:"created"`
+	Skipped int `json:"skipped"`
+}
+
+type calDAVEvent struct {
+	Title       string
+	Description string
+	Location    string
+	Date        time.Time
+}
+
+// CalDAVSyncService imports CalDAV VEVENTs into Meerkat activities.
+type CalDAVSyncService struct {
+	client      *http.Client
+	validateURL func(string) (*url.URL, error)
+}
+
+// NewCalDAVSyncService creates a CalDAV sync service with SSRF-safe fetching.
+func NewCalDAVSyncService() *CalDAVSyncService {
+	return &CalDAVSyncService{
+		client:      httputil.NewSafeHTTPClient(30 * time.Second),
+		validateURL: httputil.ValidateURLForSSRF,
+	}
+}
+
+// Sync fetches a CalDAV calendar once and imports valid VEVENTs as user activities.
+func (s *CalDAVSyncService) Sync(ctx context.Context, db *gorm.DB, userID uint, input models.CalDAVSyncInput) (CalDAVSyncResult, error) {
+	if s.client == nil {
+		s.client = httputil.NewSafeHTTPClient(30 * time.Second)
+	}
+	if s.validateURL == nil {
+		s.validateURL = httputil.ValidateURLForSSRF
+	}
+
+	parsedURL, err := s.validateURL(strings.TrimSpace(input.URL))
+	if err != nil {
+		return CalDAVSyncResult{}, fmt.Errorf("invalid calendar URL: %w", err)
+	}
+
+	contactIDs := uniqueUintIDs(input.ContactIDs)
+	contacts, err := loadUserContacts(db, userID, contactIDs)
+	if err != nil {
+		return CalDAVSyncResult{}, err
+	}
+
+	payloads, err := s.fetchCalendarPayloads(ctx, parsedURL.String(), input.Username, input.Password)
+	if err != nil {
+		return CalDAVSyncResult{}, err
+	}
+
+	var events []calDAVEvent
+	for _, payload := range payloads {
+		parsedEvents, parseErr := parseICalendarEvents(payload)
+		if parseErr != nil {
+			return CalDAVSyncResult{}, parseErr
+		}
+		events = append(events, parsedEvents...)
+	}
+
+	limit := input.Limit
+	if limit <= 0 || limit > defaultCalDAVSyncLimit {
+		limit = defaultCalDAVSyncLimit
+	}
+	if len(events) > limit {
+		events = events[:limit]
+	}
+
+	var result CalDAVSyncResult
+	err = db.Transaction(func(tx *gorm.DB) error {
+		for _, event := range events {
+			var existing models.Activity
+			err := tx.Where(
+				"user_id = ? AND title = ? AND date = ? AND location = ?",
+				userID,
+				event.Title,
+				event.Date,
+				event.Location,
+			).First(&existing).Error
+			if err == nil {
+				result.Skipped++
+				continue
+			}
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				return err
+			}
+
+			activity := models.Activity{
+				UserID:      userID,
+				Title:       event.Title,
+				Description: event.Description,
+				Location:    event.Location,
+				Date:        event.Date,
+			}
+			if err := tx.Create(&activity).Error; err != nil {
+				return err
+			}
+			if len(contacts) > 0 {
+				if err := tx.Model(&activity).Association("Contacts").Append(contacts); err != nil {
+					return err
+				}
+			}
+			result.Created++
+		}
+		return nil
+	})
+	if err != nil {
+		return CalDAVSyncResult{}, fmt.Errorf("failed to import CalDAV activities: %w", err)
+	}
+
+	return result, nil
+}
+
+func (s *CalDAVSyncService) fetchCalendarPayloads(ctx context.Context, calendarURL, username, password string) ([]string, error) {
+	reportBody := `<?xml version="1.0" encoding="utf-8" ?>
+<c:calendar-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+  <d:prop>
+    <d:getetag />
+    <c:calendar-data />
+  </d:prop>
+  <c:filter>
+    <c:comp-filter name="VCALENDAR">
+      <c:comp-filter name="VEVENT" />
+    </c:comp-filter>
+  </c:filter>
+</c:calendar-query>`
+
+	respBody, status, err := s.doCalendarRequest(ctx, http.MethodPost, calendarURL, username, password, reportBody)
+	if err != nil {
+		return nil, err
+	}
+	if status == http.StatusMethodNotAllowed || status == http.StatusNotImplemented {
+		respBody, status, err = s.doCalendarRequest(ctx, http.MethodGet, calendarURL, username, password, "")
+		if err != nil {
+			return nil, err
+		}
+	}
+	if status < 200 || status >= 300 {
+		return nil, fmt.Errorf("calendar service returned %d", status)
+	}
+
+	payloads := extractCalendarPayloads(respBody)
+	if len(payloads) == 0 {
+		return nil, fmt.Errorf("calendar response did not include VEVENT data")
+	}
+	return payloads, nil
+}
+
+func (s *CalDAVSyncService) doCalendarRequest(ctx context.Context, method, calendarURL, username, password, body string) ([]byte, int, error) {
+	requestMethod := method
+	if method == http.MethodPost {
+		requestMethod = "REPORT"
+	}
+
+	req, err := http.NewRequestWithContext(ctx, requestMethod, calendarURL, strings.NewReader(body))
+	if err != nil {
+		return nil, 0, err
+	}
+	if username != "" || password != "" {
+		req.SetBasicAuth(username, password)
+	}
+	req.Header.Set("User-Agent", "MeerkatCRM/1.0 CalDAV Sync")
+	if requestMethod == "REPORT" {
+		req.Header.Set("Depth", "1")
+		req.Header.Set("Content-Type", "application/xml; charset=utf-8")
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	limitedReader := io.LimitReader(resp.Body, maxCalDAVResponseSize+1)
+	respBody, err := io.ReadAll(limitedReader)
+	if err != nil {
+		return nil, 0, err
+	}
+	if len(respBody) > maxCalDAVResponseSize {
+		return nil, 0, fmt.Errorf("calendar response is too large")
+	}
+
+	return respBody, resp.StatusCode, nil
+}
+
+func extractCalendarPayloads(responseBody []byte) []string {
+	raw := string(responseBody)
+	if strings.Contains(raw, "BEGIN:VCALENDAR") && !strings.Contains(raw, "<") {
+		return []string{raw}
+	}
+
+	var payloads []string
+	decoder := xml.NewDecoder(bytes.NewReader(responseBody))
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			if strings.Contains(raw, "BEGIN:VCALENDAR") {
+				return []string{raw}
+			}
+			return nil
+		}
+
+		start, ok := token.(xml.StartElement)
+		if !ok || start.Name.Local != "calendar-data" {
+			continue
+		}
+
+		var payload string
+		if err := decoder.DecodeElement(&payload, &start); err != nil {
+			return nil
+		}
+		if strings.TrimSpace(payload) != "" {
+			payloads = append(payloads, payload)
+		}
+	}
+
+	if len(payloads) == 0 && strings.Contains(raw, "BEGIN:VCALENDAR") {
+		return []string{raw}
+	}
+	return payloads
+}
+
+func parseICalendarEvents(payload string) ([]calDAVEvent, error) {
+	lines := unfoldICalLines(payload)
+	var events []calDAVEvent
+	var current map[string]icalProperty
+	inEvent := false
+
+	for _, line := range lines {
+		upperLine := strings.ToUpper(strings.TrimSpace(line))
+		switch upperLine {
+		case "BEGIN:VEVENT":
+			current = make(map[string]icalProperty)
+			inEvent = true
+			continue
+		case "END:VEVENT":
+			if inEvent {
+				if event, ok := buildCalDAVEvent(current); ok {
+					events = append(events, event)
+				}
+			}
+			current = nil
+			inEvent = false
+			continue
+		}
+
+		if !inEvent {
+			continue
+		}
+		property, ok := parseICalProperty(line)
+		if ok {
+			if _, exists := current[property.Name]; !exists {
+				current[property.Name] = property
+			}
+		}
+	}
+
+	return events, nil
+}
+
+type icalProperty struct {
+	Name   string
+	Params map[string]string
+	Value  string
+}
+
+func parseICalProperty(line string) (icalProperty, bool) {
+	separator := strings.Index(line, ":")
+	if separator < 0 {
+		return icalProperty{}, false
+	}
+
+	left := line[:separator]
+	value := line[separator+1:]
+	parts := strings.Split(left, ";")
+	if len(parts) == 0 || strings.TrimSpace(parts[0]) == "" {
+		return icalProperty{}, false
+	}
+
+	property := icalProperty{
+		Name:   strings.ToUpper(strings.TrimSpace(parts[0])),
+		Params: make(map[string]string),
+		Value:  unescapeICalValue(value),
+	}
+	for _, part := range parts[1:] {
+		key, val, ok := strings.Cut(part, "=")
+		if !ok {
+			continue
+		}
+		property.Params[strings.ToUpper(strings.TrimSpace(key))] = strings.Trim(strings.TrimSpace(val), `"`)
+	}
+
+	return property, true
+}
+
+func buildCalDAVEvent(properties map[string]icalProperty) (calDAVEvent, bool) {
+	start, ok := properties["DTSTART"]
+	if !ok {
+		return calDAVEvent{}, false
+	}
+
+	eventDate, err := parseICalDate(start.Value, start.Params)
+	if err != nil {
+		return calDAVEvent{}, false
+	}
+
+	title := strings.TrimSpace(properties["SUMMARY"].Value)
+	if title == "" {
+		title = "Untitled calendar event"
+	}
+
+	return calDAVEvent{
+		Title:       clampString(title, 200),
+		Description: clampString(properties["DESCRIPTION"].Value, 2000),
+		Location:    clampString(properties["LOCATION"].Value, 300),
+		Date:        eventDate,
+	}, true
+}
+
+func parseICalDate(value string, params map[string]string) (time.Time, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, fmt.Errorf("empty iCalendar date")
+	}
+
+	if params["VALUE"] == "DATE" || (len(value) == len("20060102") && !strings.Contains(value, "T")) {
+		parsed, err := time.Parse("20060102", value)
+		if err != nil {
+			return time.Time{}, err
+		}
+		return parsed.UTC(), nil
+	}
+
+	if strings.HasSuffix(value, "Z") {
+		parsed, err := time.Parse("20060102T150405Z", value)
+		if err != nil {
+			return time.Time{}, err
+		}
+		return parsed.UTC(), nil
+	}
+
+	location := time.UTC
+	if timezoneID := params["TZID"]; timezoneID != "" {
+		if loadedLocation, err := time.LoadLocation(timezoneID); err == nil {
+			location = loadedLocation
+		}
+	}
+
+	for _, layout := range []string{"20060102T150405", "20060102T1504"} {
+		parsed, err := time.ParseInLocation(layout, value, location)
+		if err == nil {
+			return parsed.UTC(), nil
+		}
+	}
+
+	return time.Time{}, fmt.Errorf("invalid iCalendar date %q", value)
+}
+
+func unfoldICalLines(payload string) []string {
+	normalized := strings.ReplaceAll(payload, "\r\n", "\n")
+	normalized = strings.ReplaceAll(normalized, "\r", "\n")
+
+	var lines []string
+	for _, line := range strings.Split(normalized, "\n") {
+		if line == "" {
+			continue
+		}
+		if (strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t")) && len(lines) > 0 {
+			lines[len(lines)-1] += strings.TrimLeft(line, " \t")
+			continue
+		}
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+func unescapeICalValue(value string) string {
+	replacer := strings.NewReplacer(
+		`\\`, `\`,
+		`\n`, "\n",
+		`\N`, "\n",
+		`\,`, ",",
+		`\;`, ";",
+	)
+	return replacer.Replace(strings.TrimSpace(value))
+}
+
+func uniqueUintIDs(ids []uint) []uint {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	seen := make(map[uint]struct{}, len(ids))
+	for _, id := range ids {
+		if id > 0 {
+			seen[id] = struct{}{}
+		}
+	}
+
+	unique := make([]uint, 0, len(seen))
+	for id := range seen {
+		unique = append(unique, id)
+	}
+	sort.Slice(unique, func(i, j int) bool { return unique[i] < unique[j] })
+	return unique
+}
+
+func loadUserContacts(db *gorm.DB, userID uint, contactIDs []uint) ([]models.Contact, error) {
+	if len(contactIDs) == 0 {
+		return nil, nil
+	}
+
+	var contacts []models.Contact
+	if err := db.Where("user_id = ? AND id IN ?", userID, contactIDs).Find(&contacts).Error; err != nil {
+		return nil, err
+	}
+	if len(contacts) != len(contactIDs) {
+		return nil, fmt.Errorf("one or more contacts not found for current user")
+	}
+	return contacts, nil
+}
+
+func clampString(value string, maxRunes int) string {
+	value = strings.TrimSpace(value)
+	runes := []rune(value)
+	if len(runes) <= maxRunes {
+		return value
+	}
+	return string(runes[:maxRunes])
+}

--- a/backend/services/caldav_sync_service_test.go
+++ b/backend/services/caldav_sync_service_test.go
@@ -1,0 +1,166 @@
+package services
+
+import (
+	"context"
+	"encoding/base64"
+	"meerkat/models"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func setupCalDAVSyncTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Contact{}, &models.Activity{}))
+
+	return db
+}
+
+func testCalDAVSyncService(client *http.Client) *CalDAVSyncService {
+	return &CalDAVSyncService{
+		client: client,
+		validateURL: func(rawURL string) (*url.URL, error) {
+			return url.Parse(rawURL)
+		},
+	}
+}
+
+func TestCalDAVSyncCreatesActivitiesFromCalendarData(t *testing.T) {
+	db := setupCalDAVSyncTestDB(t)
+	user := models.User{Username: "tester", Password: "password123", Email: "tester@example.com"}
+	require.NoError(t, db.Create(&user).Error)
+	contact := models.Contact{UserID: user.ID, Firstname: "Ada", Lastname: "Lovelace"}
+	require.NoError(t, db.Create(&contact).Error)
+
+	var sawReport bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawReport = true
+		assert.Equal(t, "REPORT", r.Method)
+		assert.Equal(t, "1", r.Header.Get("Depth"))
+		assert.Equal(t, "Basic "+base64.StdEncoding.EncodeToString([]byte("calendar:secret")), r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+  <d:response>
+    <d:propstat>
+      <d:prop>
+        <c:calendar-data><![CDATA[BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:planning-1
+SUMMARY:Planning lunch
+DESCRIPTION:Talk through the next project
+LOCATION:Cafe Central
+DTSTART:20260512T130000Z
+END:VEVENT
+END:VCALENDAR]]></c:calendar-data>
+      </d:prop>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:propstat>
+      <d:prop>
+        <c:calendar-data>BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:call-2
+SUMMARY:Check-in call
+DESCRIPTION:Remote catch up
+LOCATION:Video
+DTSTART;VALUE=DATE:20260513
+END:VEVENT
+END:VCALENDAR</c:calendar-data>
+      </d:prop>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`))
+	}))
+	defer server.Close()
+
+	service := testCalDAVSyncService(server.Client())
+	result, err := service.Sync(context.Background(), db, user.ID, models.CalDAVSyncInput{
+		URL:        server.URL + "/calendars/tester/main/",
+		Username:   "calendar",
+		Password:   "secret",
+		ContactIDs: []uint{contact.ID},
+	})
+	require.NoError(t, err)
+	assert.True(t, sawReport)
+	assert.Equal(t, 2, result.Created)
+	assert.Equal(t, 0, result.Skipped)
+
+	var activities []models.Activity
+	require.NoError(t, db.Preload("Contacts").Order("date asc").Find(&activities).Error)
+	require.Len(t, activities, 2)
+	assert.Equal(t, "Planning lunch", activities[0].Title)
+	assert.Equal(t, "Talk through the next project", activities[0].Description)
+	assert.Equal(t, "Cafe Central", activities[0].Location)
+	assert.Equal(t, time.Date(2026, 5, 12, 13, 0, 0, 0, time.UTC), activities[0].Date)
+	require.Len(t, activities[0].Contacts, 1)
+	assert.Equal(t, contact.ID, activities[0].Contacts[0].ID)
+	assert.Equal(t, "Check-in call", activities[1].Title)
+	assert.Equal(t, time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC), activities[1].Date)
+
+	result, err = service.Sync(context.Background(), db, user.ID, models.CalDAVSyncInput{
+		URL:        server.URL + "/calendars/tester/main/",
+		Username:   "calendar",
+		Password:   "secret",
+		ContactIDs: []uint{contact.ID},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Created)
+	assert.Equal(t, 2, result.Skipped)
+}
+
+func TestCalDAVSyncRejectsContactsFromOtherUsers(t *testing.T) {
+	db := setupCalDAVSyncTestDB(t)
+	user := models.User{Username: "tester", Password: "password123", Email: "tester@example.com"}
+	otherUser := models.User{Username: "other", Password: "password123", Email: "other@example.com"}
+	require.NoError(t, db.Create(&user).Error)
+	require.NoError(t, db.Create(&otherUser).Error)
+	foreignContact := models.Contact{UserID: otherUser.ID, Firstname: "Grace", Lastname: "Hopper"}
+	require.NoError(t, db.Create(&foreignContact).Error)
+
+	service := testCalDAVSyncService(http.DefaultClient)
+	_, err := service.Sync(context.Background(), db, user.ID, models.CalDAVSyncInput{
+		URL:        "https://calendar.example.com/dav/",
+		Username:   "calendar",
+		Password:   "secret",
+		ContactIDs: []uint{foreignContact.ID},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "one or more contacts")
+
+	var count int64
+	require.NoError(t, db.Model(&models.Activity{}).Count(&count).Error)
+	assert.EqualValues(t, 0, count)
+}
+
+func TestParseICalendarEventsHandlesFoldedLinesAndTimezones(t *testing.T) {
+	events, err := parseICalendarEvents(`BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:folded
+SUMMARY:Long summary
+DESCRIPTION:First line\nSecond line with a folded
+ continuation
+LOCATION:Office\, Room 2
+DTSTART;TZID=America/New_York:20260514T090000
+END:VEVENT
+END:VCALENDAR`)
+
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, "Long summary", events[0].Title)
+	assert.Equal(t, "First line\nSecond line with a foldedcontinuation", events[0].Description)
+	assert.Equal(t, "Office, Room 2", events[0].Location)
+	assert.Equal(t, time.Date(2026, 5, 14, 13, 0, 0, 0, time.UTC), events[0].Date)
+}

--- a/frontend/src/SettingsPage.tsx
+++ b/frontend/src/SettingsPage.tsx
@@ -24,10 +24,12 @@ import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import DownloadIcon from '@mui/icons-material/Download';
 import InfoIcon from '@mui/icons-material/Info';
 import GitHubIcon from '@mui/icons-material/GitHub';
+import SyncIcon from '@mui/icons-material/Sync';
 import Link from '@mui/material/Link';
 import { changePassword } from './api/auth';
 import { updateLanguage, updateDateFormat } from './api/users';
 import { exportDataAsCsv, exportContactsAsVcf } from './api/export';
+import { syncCalDAVActivities } from './api/caldav';
 import { ThemePreference, useThemePreference } from './AppThemeProvider';
 import { DateFormat, useDateFormat } from './DateFormatProvider';
 import CustomFieldsSettings from './components/CustomFieldsSettings';
@@ -48,6 +50,13 @@ export default function SettingsPage() {
   const [exportingVcf, setExportingVcf] = useState(false);
   const [exportVcfError, setExportVcfError] = useState('');
   const [exportVcfSuccess, setExportVcfSuccess] = useState('');
+  const [calDAVUrl, setCalDAVUrl] = useState('');
+  const [calDAVUsername, setCalDAVUsername] = useState('');
+  const [calDAVPassword, setCalDAVPassword] = useState('');
+  const [calDAVLimit, setCalDAVLimit] = useState('200');
+  const [syncingCalDAV, setSyncingCalDAV] = useState(false);
+  const [calDAVError, setCalDAVError] = useState('');
+  const [calDAVSuccess, setCalDAVSuccess] = useState('');
 
   const handleLanguageChange = async (event: any) => {
     const newLang = event.target.value;
@@ -112,6 +121,39 @@ export default function SettingsPage() {
       setExportVcfError(errorMessage);
     } finally {
       setExportingVcf(false);
+    }
+  };
+
+  const handleCalDAVSync = async (event: FormEvent) => {
+    event.preventDefault();
+    setCalDAVError('');
+    setCalDAVSuccess('');
+
+    if (!calDAVUrl.trim() || !calDAVUsername.trim() || !calDAVPassword) {
+      setCalDAVError(t('settings.caldav.required'));
+      return;
+    }
+
+    const parsedLimit = Number.parseInt(calDAVLimit, 10);
+    setSyncingCalDAV(true);
+
+    try {
+      const result = await syncCalDAVActivities({
+        url: calDAVUrl.trim(),
+        username: calDAVUsername.trim(),
+        password: calDAVPassword,
+        limit: Number.isFinite(parsedLimit) ? parsedLimit : undefined,
+      });
+      setCalDAVSuccess(t('settings.caldav.success', {
+        created: result.created,
+        skipped: result.skipped,
+      }));
+      setCalDAVPassword('');
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : t('settings.caldav.error');
+      setCalDAVError(errorMessage);
+    } finally {
+      setSyncingCalDAV(false);
     }
   };
 
@@ -282,6 +324,74 @@ export default function SettingsPage() {
       </Card>
 
       <CustomFieldsSettings />
+
+      <Card sx={{ mb: 2 }}>
+        <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+            <SyncIcon sx={{ mr: 1, color: 'text.secondary', fontSize: 20 }} />
+            <Typography variant="subtitle1" sx={{ fontWeight: 500 }}>
+              {t('settings.caldav.title')}
+            </Typography>
+          </Box>
+          <Divider sx={{ mb: 1.5 }} />
+
+          <form onSubmit={handleCalDAVSync}>
+            <Stack spacing={1.5}>
+              <Typography variant="body2" color="text.secondary">
+                {t('settings.caldav.description')}
+              </Typography>
+              {calDAVError && <Alert severity="error" sx={{ py: 0 }}>{calDAVError}</Alert>}
+              {calDAVSuccess && <Alert severity="success" sx={{ py: 0 }}>{calDAVSuccess}</Alert>}
+              <TextField
+                label={t('settings.caldav.url')}
+                type="url"
+                value={calDAVUrl}
+                onChange={event => setCalDAVUrl(event.target.value)}
+                fullWidth
+                required
+                size="small"
+              />
+              <Box sx={{ display: 'grid', gap: 1.5, gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' } }}>
+                <TextField
+                  label={t('settings.caldav.username')}
+                  value={calDAVUsername}
+                  onChange={event => setCalDAVUsername(event.target.value)}
+                  fullWidth
+                  required
+                  size="small"
+                />
+                <TextField
+                  label={t('settings.caldav.password')}
+                  type="password"
+                  value={calDAVPassword}
+                  onChange={event => setCalDAVPassword(event.target.value)}
+                  fullWidth
+                  required
+                  size="small"
+                />
+              </Box>
+              <TextField
+                label={t('settings.caldav.limit')}
+                type="number"
+                value={calDAVLimit}
+                onChange={event => setCalDAVLimit(event.target.value)}
+                inputProps={{ min: 1, max: 200 }}
+                size="small"
+                sx={{ maxWidth: 180 }}
+              />
+              <Button
+                type="submit"
+                variant="contained"
+                size="small"
+                startIcon={syncingCalDAV ? <CircularProgress size={16} color="inherit" /> : <CalendarMonthIcon />}
+                disabled={syncingCalDAV}
+              >
+                {syncingCalDAV ? t('settings.caldav.syncing') : t('settings.caldav.syncButton')}
+              </Button>
+            </Stack>
+          </form>
+        </CardContent>
+      </Card>
 
       <Card sx={{ mb: 2 }}>
         <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>

--- a/frontend/src/api/caldav.ts
+++ b/frontend/src/api/caldav.ts
@@ -1,0 +1,34 @@
+import { apiFetch, API_BASE_URL, getAuthHeaders, parseErrorResponse } from './client';
+
+export interface CalDAVSyncRequest {
+  url: string;
+  username: string;
+  password: string;
+  limit?: number;
+}
+
+export interface CalDAVSyncResponse {
+  message: string;
+  created: number;
+  skipped: number;
+}
+
+export async function syncCalDAVActivities(
+  data: CalDAVSyncRequest
+): Promise<CalDAVSyncResponse> {
+  const response = await apiFetch(
+    `${API_BASE_URL}/caldav/sync`,
+    {
+      method: 'POST',
+      headers: getAuthHeaders(),
+      body: JSON.stringify(data),
+    },
+    60000
+  );
+
+  if (!response.ok) {
+    throw await parseErrorResponse(response);
+  }
+
+  return response.json();
+}

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -387,6 +387,19 @@
         "dark": "Dunkles Design"
       }
     },
+    "caldav": {
+      "title": "CalDAV-Aktivitaetssync",
+      "description": "Verbinden Sie einen CalDAV-Kalender und importieren Sie geplante Termine als Aktivitaeten. Zugangsdaten werden nur fuer diesen Sync verwendet.",
+      "url": "Kalender-URL",
+      "username": "Benutzername",
+      "password": "Passwort",
+      "limit": "Terminlimit",
+      "syncButton": "Aktivitaeten synchronisieren",
+      "syncing": "Synchronisiere...",
+      "required": "Kalender-URL, Benutzername und Passwort sind erforderlich.",
+      "success": "CalDAV-Sync abgeschlossen: {{created}} erstellt, {{skipped}} uebersprungen.",
+      "error": "CalDAV-Aktivitaeten konnten nicht synchronisiert werden. Bitte versuchen Sie es erneut."
+    },
     "password": {
       "title": "Passwort ändern",
       "description": "Verwenden Sie ein starkes Passwort, das Sie noch nicht genutzt haben.",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -387,6 +387,19 @@
         "dark": "Dark mode"
       }
     },
+    "caldav": {
+      "title": "CalDAV Activity Sync",
+      "description": "Connect to a CalDAV calendar and import planned events as activities. Credentials are used for this sync only.",
+      "url": "Calendar URL",
+      "username": "Username",
+      "password": "Password",
+      "limit": "Event limit",
+      "syncButton": "Sync activities",
+      "syncing": "Syncing...",
+      "required": "Calendar URL, username, and password are required.",
+      "success": "CalDAV sync completed: {{created}} created, {{skipped}} skipped.",
+      "error": "Failed to sync CalDAV activities. Please try again."
+    },
     "password": {
       "title": "Change Password",
       "description": "Use a strong password that you haven't used elsewhere.",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -387,6 +387,19 @@
         "dark": "Modalità scura"
       }
     },
+    "caldav": {
+      "title": "Sincronizzazione attivita CalDAV",
+      "description": "Connetti un calendario CalDAV e importa gli eventi pianificati come attivita. Le credenziali sono usate solo per questa sincronizzazione.",
+      "url": "URL calendario",
+      "username": "Nome utente",
+      "password": "Password",
+      "limit": "Limite eventi",
+      "syncButton": "Sincronizza attivita",
+      "syncing": "Sincronizzazione...",
+      "required": "URL calendario, nome utente e password sono obbligatori.",
+      "success": "Sincronizzazione CalDAV completata: {{created}} creati, {{skipped}} saltati.",
+      "error": "Impossibile sincronizzare le attivita CalDAV. Riprova."
+    },
     "password": {
       "title": "Cambia Password",
       "description": "Usa una password forte che non hai usato altrove.",


### PR DESCRIPTION
## Summary

Addresses #128 by adding a focused CalDAV activity import path:

- adds an authenticated `POST /api/v1/caldav/sync` endpoint
- imports VEVENT data from CalDAV `REPORT` responses, with a plain `GET` fallback for simpler calendar exports
- parses common iCalendar dates, time zones, folded lines, escaped values, summaries, descriptions, and locations
- creates activities for the current user and skips duplicate imports by user/title/date/location
- optionally associates imported activities with user-owned contacts
- adds a Settings page sync form with English, German, and Italian labels

CalDAV credentials are used only for the sync request and are not stored. The outbound calendar request uses the same SSRF-safe HTTP client path as the existing image fetcher.

## Validation

- `docker.exe run --rm -v ".../backend:/app" -w /app golang:1.25.3-alpine go test ./...`
- `corepack.cmd yarn build`
- `git diff --cached --check`

