### PR TITLE
Render newlines in textfields

### DIFF
--- a/frontend/src/components/EditableField.tsx
+++ b/frontend/src/components/EditableField.tsx
@@ -85,7 +85,7 @@ export default function EditableField({
               )}
             </Box>
           ) : (
-            <Typography variant="body1" sx={{ wordBreak: 'break-word' }}>
+            <Typography variant="body1" sx={{ wordBreak: 'break-word', whiteSpace: multiline ? 'pre-wrap' : undefined }}>
               {displayValue}
             </Typography>
           )}


### PR DESCRIPTION
Display multiline text correctly in the contact text fields (e.g. additional information field). Retroactively applies to already saved text (was just a rendering issue).